### PR TITLE
Resolve some htmlhint errors

### DIFF
--- a/_includes/blog-roll.html
+++ b/_includes/blog-roll.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <ul class="roll">
 {% for post in site.posts %}
     <li class="roll-item">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <footer>
     <div class="squeeze">
         <h2>Ben Cunningham</h2>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
 <head>
 
     <title>{{ site.title }}: {{ page.title }}</title>
-    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ '/css/main.css' | prepend: site.baseurl }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% if page.summary %}
     <meta name="description" content="{{ page.summary | escape }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <head>
 
     <title>{{ site.title }}: {{ page.title }}</title>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,22 +3,18 @@ layout: default
 ---
 
 <header>
-    <div class="site-title">
-		<div class="squeeze">
-            <h2>
-                Ben Cunningham
-            </h2>
-		</div>
-    </div>
+  <div class="site-title">
     <div class="squeeze">
-        <div class="post-header">
-			{{ content }}
-        </div>
+      <h2>Ben Cunningham</h2>
     </div>
+  </div>
+  <div class="squeeze">
+    <div class="post-header">
+      {{ content }}
+    </div>
+  </div>
 </header>
 
 <main>
-
-    {% include blog-roll.html %}
-
+{% include blog-roll.html %}
 </main>

--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -3,46 +3,42 @@ layout: default
 ---
 
 <header>
-    <div class="site-title">
-        <div class="squeeze">
-            <h2>
-                <a href="{{ site.baseurl }}/index.html">
-                    Ben Cunningham
-                </a>
-            </h2>
-        </div>
-    </div>
+  <div class="site-title">
     <div class="squeeze">
-        <div class="post-header">
-            <h1>Tags</h1>
-        </div>
+      <h2>
+        <a href="{{ site.baseurl }}/index.html">Ben Cunningham</a>
+      </h2>
     </div>
+  </div>
+  <div class="squeeze">
+    <div class="post-header">
+      <h1>Tags</h1>
+    </div>
+  </div>
 </header>
 
 <main>
 
 {% assign tags = "" | split: "" %}
 {% for post in site.posts %}
-    {% for tag in post.tags %}
-        {% assign tags = tags | push: tag %}
-    {% endfor %}
+  {% for tag in post.tags %}
+    {% assign tags = tags | push: tag %}
+  {% endfor %}
 {% endfor %}
 {% assign tags = tags | uniq | sort %}
 
 {% for tag in tags %}
-<h1 id="{{ tag }}">{{ tag }}</h2>
+<h1 id="{{ tag }}">{{ tag }}</h1>
 <ul class="roll tag-roll">
 {% for post in site.posts %}
-    {% if post.tags contains tag %}
-    <li class="roll-item">
-        <span class="meta">
-            {{ post.date | date: "%B %d, %Y" }}
-        </span>
-        <a href="{{ post.url }}">
-            {{ post.title }}
-        </a>
-    </li>
-    {% endif %}
+  {% if post.tags contains tag %}
+  <li class="roll-item">
+    <span class="meta">
+      {{ post.date | date: "%B %d, %Y" }}
+    </span>
+    <a href="{{ post.url }}">{{ post.title }}</a>
+  </li>
+  {% endif %}
 {% endfor %}
 </ul>
 {% endfor %}


### PR DESCRIPTION
Addresses #31.

# What's out of scope?

```
❌ [ERROR] for workspace /tmp/lint
Linter raw log:

   Config loaded: /action/lib/.automation/.htmlhintrc

   Config loaded: /action/lib/.automation/.htmlhintrc

   Config loaded: /action/lib/.automation/.htmlhintrc

   /tmp/lint/_includes/head.html
      L14 |        <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=...
                   ^ The <script> tag cannot be used in a <head> tag. (head-script-disabled)

   Config loaded: /action/lib/.automation/.htmlhintrc

   Config loaded: /action/lib/.automation/.htmlhintrc

   /tmp/lint/_layouts/home.html
      L1 |---
          ^ Doctype must be declared first. (doctype-first)

   Config loaded: /action/lib/.automation/.htmlhintrc

   /tmp/lint/_layouts/post.html
      L1 |---
          ^ Doctype must be declared first. (doctype-first)

   Config loaded: /action/lib/.automation/.htmlhintrc

   /tmp/lint/_layouts/tags.html
      L1 |---
          ^ Doctype must be declared first. (doctype-first)
      L31 |<h1 id="{{ tag }}">{{ tag }}</h1>
              ^ The id and class attribute values must be in lowercase and split by a dash. (id-class-value)

   Config loaded: /action/lib/.automation/.htmlhintrc

   /tmp/lint/tags/index.html
      L1 |---
          ^ Doctype must be declared first. (doctype-first)

Scanned 8 files, found 6 errors in 5 files (87 ms)
```